### PR TITLE
Improve deploy Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Conversation that helped fix the code to make it deploy: https://www.perplexity.
 
 Not so helpful conversation with Gemini, which however includes instructions on how to configure AppEngine SA to permit access to GHC DICOM store: https://g.co/gemini/share/46ab5254e2c8
 
+## Configuration 
+
+The default function name is `proxy`. You can use a different function name, however, that requires a slightly different setup **before** running the commands above.
+First, set `GCP_DICOMWEB_PROXY_FN_NAME=your_fn_name`. You then also need to change the exported function name in `index.js` in line `48`: `exports.your_fn_name = async (req, res) => {`.
+
 ## Permissions
 
 Service account used by the function is listed under details of the function in https://console.cloud.google.com/functions.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Deploy command:
 
 ```bash
 GCP_DICOMWEB_PROXY_FN_NAME=proxy
+
 gcloud functions deploy $GCP_DICOMWEB_PROXY_FN_NAME \
   --runtime nodejs20 \
   --trigger-http \
@@ -14,10 +15,24 @@ gcloud functions deploy $GCP_DICOMWEB_PROXY_FN_NAME \
   --no-gen2
 ```
 
+To make a dicomstore available throug the proxy, replace PROJECT, LOCATION, DATASET and STORE with your actual values in the `GCP_DICOMWEB_PROXY_DICOMURL` variable.
+Then run the following command to deploy the function with the updated DICOMURL set as environment variable.
+
+```
+GCP_DICOMWEB_PROXY_FN_NAME=proxy
+GCP_DICOMWEB_PROXY_DICOMURL="https://healthcare.googleapis.com/v1/projects/PROJECT/locations/LOCATION/datasets/DATASET/dicomStores/STORE/dicomWeb"
+
+gcloud functions deploy $GCP_DICOMWEB_PROXY_FN_NAME \
+  --update-env-vars DICOMURL="$GCP_DICOMWEB_PROXY_DICOMURL" \
+  --region us-central1 \
+  --no-gen2
+```
+
 After deploying, run the following if you want it to be accessible to all users (you will need `cloudfunctions.functions.setIamPolicy` IAM permission to perform this operation):
 
 ```bash
 GCP_DICOMWEB_PROXY_FN_NAME=proxy
+
 gcloud functions add-iam-policy-binding $GCP_DICOMWEB_PROXY_FN_NAME \
   --region=us-central1 \
   --member=allUsers \

--- a/README.md
+++ b/README.md
@@ -5,16 +5,23 @@
 Deploy command:
 
 ```bash
-gcloud functions deploy proxy --runtime nodejs20 --trigger-http --allow-unauthenticated --no-gen2
+GCP_DICOMWEB_PROXY_FN_NAME=proxy
+gcloud functions deploy $GCP_DICOMWEB_PROXY_FN_NAME \
+  --runtime nodejs20 \
+  --trigger-http \
+  --allow-unauthenticated \
+  --no-gen2
 ```
 
 After deploying, run the following if you want it to be accessible to all users (you will need `cloudfunctions.functions.setIamPolicy` IAM permission to perform this operation):
 
 ```bash
-gcloud functions add-iam-policy-binding prostate_seg_proxy --region=us-central1 --member=allUsers --role=roles/cloudfunctions.invoker
+GCP_DICOMWEB_PROXY_FN_NAME=proxy
+gcloud functions add-iam-policy-binding $GCP_DICOMWEB_PROXY_FN_NAME \
+  --region=us-central1 \
+  --member=allUsers \
+  --role=roles/cloudfunctions.invoker
 ```
-
-
 
 Conversation that helped fix the code to make it deploy: https://www.perplexity.ai/search/i-am-trying-to-deploy-a-google-BjRoJupjQ2eup440PQOEAQ
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ gcloud functions deploy $GCP_DICOMWEB_PROXY_FN_NAME \
   --runtime nodejs20 \
   --trigger-http \
   --allow-unauthenticated \
+  --entry-point proxy \
   --no-gen2
 ```
 
@@ -26,11 +27,6 @@ gcloud functions add-iam-policy-binding $GCP_DICOMWEB_PROXY_FN_NAME \
 Conversation that helped fix the code to make it deploy: https://www.perplexity.ai/search/i-am-trying-to-deploy-a-google-BjRoJupjQ2eup440PQOEAQ
 
 Not so helpful conversation with Gemini, which however includes instructions on how to configure AppEngine SA to permit access to GHC DICOM store: https://g.co/gemini/share/46ab5254e2c8
-
-## Configuration 
-
-The default function name is `proxy`. You can use a different function name, however, that requires a slightly different setup **before** running the commands above.
-First, set `GCP_DICOMWEB_PROXY_FN_NAME=your_fn_name`. You then also need to change the exported function name in `index.js` in line `48`: `exports.your_fn_name = async (req, res) => {`.
 
 ## Permissions
 


### PR DESCRIPTION
- highlight the variable (function name) that should be set by the user, keep `proxy` as the default.
- fix: use the same default function name (proxy) in both commands
- style: break down commands and parameters into multiple lines for better readability and to avoid overflowing (scrolling)